### PR TITLE
changes the base google messaging endpoint

### DIFF
--- a/lib/gcm.rb
+++ b/lib/gcm.rb
@@ -4,7 +4,7 @@ require 'json'
 
 class GCM
   include HTTParty
-  base_uri 'https://android.googleapis.com/gcm'
+  base_uri 'https://fcm.googleapis.com/fcm'
   default_timeout 30
   format :json
 


### PR DESCRIPTION
The master on this fork is version 0.1.0, which is the version that is being used in push_services.  This pull updates the url to fcm.