### PR TITLE
locks down gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,5 @@ bin
 cache
 gems
 specifications
-Gemfile.lock
 .rvmrc
 spec/reports

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'rake'
+gem 'rake', '10.0.4'
+gem 'public_suffix', '1.3.0'
+gem 'mime-types', '< 3'
+gem 'httparty', '0.12.0'
 gem 'rspec'
-gem 'webmock'
+gem 'webmock', '1.9.2'
 gem 'ci_reporter_rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,61 @@
+PATH
+  remote: .
+  specs:
+    gcm (0.1.0)
+      httparty
+      json
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    builder (3.2.3)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    httparty (0.12.0)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    json (1.8.6-java)
+    mime-types (2.99.3)
+    multi_xml (0.6.0)
+    public_suffix (1.3.0)
+    rake (10.0.4)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    safe_yaml (1.0.5)
+    webmock (1.9.2)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  ci_reporter_rspec
+  gcm!
+  httparty (= 0.12.0)
+  mime-types (< 3)
+  public_suffix (= 1.3.0)
+  rake (= 10.0.4)
+  rspec
+  webmock (= 1.9.2)
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
This repo didn't have a Gemfile.lock and we needed to specify certain dependencies to make this library compatible with ruby 1.9.3.